### PR TITLE
Fix #3 Remove process.exit() due to compatibility with ddp-graceful-shutdowd

### DIFF
--- a/server-presence.js
+++ b/server-presence.js
@@ -93,9 +93,6 @@ const start = () => {
 const exit = () => {
     // Call all of our externally supplied exit functions
     runCleanupFunctions(serverId);
-
-    // Exit application gracefully since we've caught SIGINT, SIGTERM and SIGHUP
-    process.exit();
 };
 
 /*


### PR DESCRIPTION
Fix #3 