### PR TITLE
Use createIndex when available

### DIFF
--- a/server-presence.js
+++ b/server-presence.js
@@ -5,8 +5,13 @@ import { Mongo } from 'meteor/mongo';
 
 const Servers = new Mongo.Collection('presence:servers');
 
-Servers._ensureIndex({ lastPing: 1 }, { expireAfterSeconds: 10 });
-Servers._ensureIndex({ createdAt: -1 });
+if (Servers.createIndex) {
+  Servers.createIndex({ lastPing: 1 }, { expireAfterSeconds: 10 });
+  Servers.createIndex({ createdAt: -1 });
+} else {
+  Servers._ensureIndex({ lastPing: 1 }, { expireAfterSeconds: 10 });
+  Servers._ensureIndex({ createdAt: -1 });
+}
 
 let serverId = null;
 let isWatcher = false;


### PR DESCRIPTION
Meteor 2.4+ use of `createIndex` instead of deprecated `_ensureIndex`.